### PR TITLE
Setup Travis CI to build Goldiriath

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: java
 
 jdk:
-- openjdk8
+- oraclejdk8
 
 before_install:
 - wget "https://github.com/Pravian/Aero/archive/master.zip" -O aero.zip

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,12 @@ language: java
 jdk:
 - openjdk7
 
-# Don't test certain branches
-branches:
-  except:
-  - master
-  - release
+before_install:
+- wget "https://github.com/Pravian/Aero/archive/master.zip" -O aero.zip
+- upzip aero.zip -d aero
+- cd aero
+- mvn install
+- cd ..
 
 # get us on the new container based builds, we're not using any fancyness
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ jdk:
 
 before_install:
 - wget "https://github.com/Pravian/Aero/archive/master.zip" -O aero.zip
-- unzip aero.zip -d aero
-- cd aero
+- unzip aero.zip -d .
+- cd Aero-master
 - mvn install
 - cd ..
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ jdk:
 
 before_install:
 - wget "https://github.com/Pravian/Aero/archive/master.zip" -O aero.zip
-- upzip aero.zip -d aero
+- unzip aero.zip -d aero
 - cd aero
 - mvn install
 - cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@
 language: java
 
 jdk:
-- openjdk7
+- openjdk8
 
 before_install:
 - wget "https://github.com/Pravian/Aero/archive/master.zip" -O aero.zip


### PR DESCRIPTION
It would be nice to have Travis CI build each commit and PR. Unfortunately, Goldiriath depends on Aero which is is not available on any Maven repository. This fix adds a `before_install` script to the .travis.yml file which downloads and installs Aero so Goldiriath can be built properly.

Squash message:
```
Setup Travis CI to build Goldiriath.
Aero is now downloaded and installed before Goldiriath is compiled.
```